### PR TITLE
Updated call to Get-AzComputeResourceSku

### DIFF
--- a/Get-VM-by-Zones/get-vms-by-zone.ps1
+++ b/Get-VM-by-Zones/get-vms-by-zone.ps1
@@ -111,7 +111,7 @@ Select-AzSubscription -Subscription $SubscriptionName -Force
 
 $output = @()
 
-$vms = Get-AzComputeResourceSku | where { $_.Locations.Contains($region) } | where { $_.ResourceType.Contains("virtualMachines") };
+$vms = Get-AzComputeResourceSku -Location $region | Where-Object { $_.ResourceType -eq 'virtualMachines' };
 
 #    $vmseries = @("M","D")
 


### PR DESCRIPTION
The Get-AzComputeResourceSku cmdlet supports location parameter. The REST api also supports the filter parameter which is currently limited to location. So, it does make sense to pass the location along with cmdlet call such that we get a filtered list of items for the specified region instead of filtering after the results are received. A measure of the execution times shows that with the location parameter passed, we get 1.5 seconds as the execution time. Whereas with the filtering done on the piped output takes 24.2 seconds to execute.

https://docs.microsoft.com/en-us/rest/api/compute/resourceskus/list

For the second where-object filter, if we shift from $_.resourceType.contains('virtualMachines') to $_resourceType -eq 'virtualMachines' we see an improvement of roughly 100ms in the execution time. The contains operation is very useful when searching through a collection. However, in our scenario the resource types are distinct and we pass them over the pipe. So a simple equality operation will suffice and could be more performant.