### PR TITLE
OS disk size to 64 GB

### DIFF
--- a/ARMTemplates/serverTemplates/AppVM.json
+++ b/ARMTemplates/serverTemplates/AppVM.json
@@ -176,7 +176,7 @@
 
         "diskSizes": {
             "ASCS": {
-                "osdiskSizeGB": 63,
+                "osdiskSizeGB": 64,
                 "nrDisks": 1
             }
         },
@@ -334,7 +334,7 @@
                         "name": "[concat(variables('sapMachineName'),'-', padLeft(copyIndex(1),2,'0'), '-osdisk')]",
                         "caching": "ReadWrite",
                         "createOption": "FromImage",
-                        "diskSizeGB": "[if(startsWith(toLower(parameters('publisher')),'microsoft') ,127, 63)]",
+                        "diskSizeGB": "[if(startsWith(toLower(parameters('publisher')),'microsoft') ,127, 64)]",
                         "managedDisk": {
                             "storageAccountType": "Premium_LRS"
 


### PR DESCRIPTION
To avoid an error when the specified disk size 63 GB is smaller than the size of the corresponding disk in the VM image: 64 GB.