### PR TITLE
Fixed return of some linux commands that return the command string as…

### DIFF
--- a/QualityCheck/QualityCheck.ps1
+++ b/QualityCheck/QualityCheck.ps1
@@ -1108,6 +1108,15 @@ function RunCommand {
                 # store the result in script variable to access it for alternative output in JSON
                 $script:_CommandResult = $_result
 
+                # Check the result and see if it's an array and if the first object in the array starts with '<'
+                # if so, then drop it from the array.
+                # This fixes an issue with some Linux commands that return the command as the first object in the array
+                if ($_result -is [array]) {
+                    if ($_result[0].StartsWith("<")) {
+                        $_result = $_result[1..($_result.Length-1)]
+                    }
+                }
+
                 # return result
                 return $_result
             }


### PR DESCRIPTION
When run on an Oracle Linux remote host, the output of the Quality Check currently returns: 

```powershell
ConvertFrom-Json: ./SAP-on-Azure-Scripts-and-Utilities/QualityCheck/QualityCheck.ps1:872
Line |
 872 |      $script:_vmmetadata = $_result | ConvertFrom-Json
     |                                       ~~~~~~~~~~~~~~~~
     | Conversion from JSON failed with error: Unexpected character encountered while parsing value: <. Path '', line 0, position 0.
ConvertFrom-Json: ./SAP-on-Azure-Scripts-and-Utilities/QualityCheck/QualityCheck.ps1:1334
Line |
1334 |  … $script:_azurediskconfig = RunCommand -p $_command | ConvertFrom-Json
     |                                                         ~~~~~~~~~~~~~~~~
     | Conversion from JSON failed with error: Unexpected character encountered while parsing value: <. Path '', line 0, position 0.
```

This is due to the return value being an array with the first object being a substring of the command that was sent to the remote host. 

This PR is my attempt at fixing it. 