### PR TITLE
Add ADE for Linux validation to prevent NVMe conversion on encrypted VMs

### DIFF
--- a/Azure-NVMe-Utils/Azure-NVMe-Conversion.ps1
+++ b/Azure-NVMe-Utils/Azure-NVMe-Conversion.ps1
@@ -188,7 +188,7 @@ function CheckForNewerVersion {
 # Main Script
 ##############################################################################################################
 
-$_version = "2025093001" # version of the script
+$_version = "2025110501" # version of the script
 
 # creating variable for log file
 $script:_runlog = @()

--- a/Azure-NVMe-Utils/Azure-NVMe-Conversion.ps1
+++ b/Azure-NVMe-Utils/Azure-NVMe-Conversion.ps1
@@ -263,23 +263,25 @@ try {
 $script:_original_vm_size = $_VM.HardwareProfile.VmSize
 
 # Check if the Azure Disk Encryption for Linux is present
-try {
-    $extension = Get-AzVMExtension -ResourceGroupName $ResourceGroupName -VMName $VMName -Name "AzureDiskEncryptionForLinux" -ErrorAction Stop
+if ($_VM.StorageProfile.OsDisk.OsType -eq "Linux") {
+    try {
+        $extension = Get-AzVMExtension -ResourceGroupName $ResourceGroupName -VMName $VMName -Name "AzureDiskEncryptionForLinux" -ErrorAction Stop
 
-    if ($extension.ProvisioningState -eq "Succeeded") {
-        WriteRunLog -message "ADE for Linux extension is installed and succeeded on VM: $($extension.VMName)" -category "ERROR"
+        if ($extension.ProvisioningState -eq "Succeeded") {
+            WriteRunLog -message "ADE for Linux extension is installed and succeeded on VM: $($extension.VMName)" -category "ERROR"
                 WriteRunLog -message "Azure Disk Encryption for Linux don't support NVMe disks" -category "ERROR"
                 WriteRunLog $_.Exception.Message "ERROR"
-        exit
-    } else {
-        WriteRunLog -message "ADE for Linux extension is installed but provisioning state is: $($extension.ProvisioningState)" -category "ERROR"
+                exit
+            } else {
+                WriteRunLog -message "ADE for Linux extension is installed but provisioning state is: $($extension.ProvisioningState)" -category "ERROR"
                 WriteRunLog -message "If the VM has not been encrypted remove the extension and try again"  -category "ERROR"
                 WriteRunLog $_.Exception.Message "ERROR"
-        exit
-    }
-}
-catch {
-    WriteRunLog -message "ADE for Linux extension is NOT installed on this VM"
+                exit
+            }
+        }
+        catch {
+            WriteRunLog -message "ADE for Linux extension is NOT installed on this VM"
+        }
 }
 
 # Get VM Power State

--- a/Azure-NVMe-Utils/Azure-NVMe-Conversion.ps1
+++ b/Azure-NVMe-Utils/Azure-NVMe-Conversion.ps1
@@ -262,6 +262,26 @@ try {
 # storing original VM Size
 $script:_original_vm_size = $_VM.HardwareProfile.VmSize
 
+# Check if the Azure Disk Encryption for Linux is present
+try {
+    $extension = Get-AzVMExtension -ResourceGroupName $ResourceGroupName -VMName $VMName -Name "AzureDiskEncryptionForLinux" -ErrorAction Stop
+
+    if ($extension.ProvisioningState -eq "Succeeded") {
+        WriteRunLog -message "ADE for Linux extension is installed and succeeded on VM: $($extension.VMName)" -category "ERROR"
+                WriteRunLog -message "Azure Disk Encryption for Linux don't support NVMe disks" -category "ERROR"
+                WriteRunLog $_.Exception.Message "ERROR"
+        exit
+    } else {
+        WriteRunLog -message "ADE for Linux extension is installed but provisioning state is: $($extension.ProvisioningState)" -category "ERROR"
+                WriteRunLog -message "If the VM has not been encrypted remove the extension and try again"  -category "ERROR"
+                WriteRunLog $_.Exception.Message "ERROR"
+        exit
+    }
+}
+catch {
+    WriteRunLog -message "ADE for Linux extension is NOT installed on this VM"
+}
+
 # Get VM Power State
 try {
     $_vminfo = Get-AzVM -ResourceGroupName $ResourceGroupName -Name $VMName -Status


### PR DESCRIPTION
# Pull Request: Add ADE Validation for NVMe Conversion on Linux VMs

## Summary
This update adds a validation step for **Azure Disk Encryption (ADE) for Linux** when converting Azure VMs from SCSI to NVMe.

## Why This Change?
Azure Disk Encryption for Linux does **not support NVMe disks**. Attempting conversion on an encrypted VM can lead to failures or unsupported configurations. This check ensures the script stops before making changes that would break ADE compatibility.

## What This Code Does
- Detects if the VM OS type is **Linux**.
- Checks for the **AzureDiskEncryptionForLinux** extension:
  - If **ProvisioningState = Succeeded**, logs an error and exits the conversion process.
  - If the extension exists but is in another state, advises removing the extension (if the VM is not encrypted) before retrying.
- If the extension is **not installed**, conversion proceeds normally.

## Benefits
- Prevents unsupported NVMe conversions on encrypted Linux VMs.
- Provides clear guidance to users when ADE is detected, reducing risk of misconfiguration.

## Reference
For more details on ADE limitations, see:  
[Azure Disk Encryption for Linux Restrictions](https://learn.microsoft.com/azure/virtual-machines/linux/disk-encryption-linux#restrictions)