### PR TITLE
Update Azure-NVMe-Conversion.ps1

### DIFF
--- a/Azure-NVMe-Utils/Azure-NVMe-Conversion.ps1
+++ b/Azure-NVMe-Utils/Azure-NVMe-Conversion.ps1
@@ -793,7 +793,7 @@ check_fstab() {
                             echo "[WARNING] Could not find UUID for $device.  Skipping."
                             echo "$line" >> /etc/fstab.new
                         fi
-                    elif [[ "$device" =~ ^/dev/disk/azure/scsi[0-9]*/lun[0-9]*$ ]]; then
+                    elif [[ "$device" =~ ^/dev/disk/azure/scsi[0-9]*/lun[0-9]* ]]; then
                         uuid=$(blkid "$device" | awk -F\" '/UUID=/ {print $2}')
                         if [ -n "$uuid" ]; then
                             newline=$(echo "$line" | sed "s|$device|UUID=$uuid|g")


### PR DESCRIPTION
Regular expression is not taking into account partitions when checking the fstab entries.

Ex: /dev/disk/azure/scsi1/lun0-part1